### PR TITLE
Fix detail pane, add filters and correct report selections

### DIFF
--- a/di-billing-app/apps/web/src/api.ts
+++ b/di-billing-app/apps/web/src/api.ts
@@ -11,16 +11,25 @@ export async function fetchDashboardStats() {
 
 // =========== Discrepancy Functions ===========
 
-// This function is simplified as filters are removed for now.
-export async function fetchDiscrepancies(query: { page?: number; pageSize?: number; sortBy?: string; sortOrder?: 'asc' | 'desc'; }) {
+// Fetch discrepancies with optional BAC and program filters.
+export async function fetchDiscrepancies(query: {
+  page?: number;
+  pageSize?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+  bac?: string;
+  program?: string;
+}) {
   const params = new URLSearchParams({
     page: String(query.page || 1),
     pageSize: String(query.pageSize || 50),
     sortBy: query.sortBy || 'variance',
-    sortOrder: query.sortOrder || 'desc'
+    sortOrder: query.sortOrder || 'desc',
   });
+  if (query.bac) params.set('bac', query.bac);
+  if (query.program) params.set('program', query.program);
   const res = await fetch(`${API_URL}/discrepancies?${params.toString()}`);
-  if (!res.ok) throw new Error("Failed to fetch discrepancies");
+  if (!res.ok) throw new Error('Failed to fetch discrepancies');
   return res.json();
 }
 
@@ -34,10 +43,11 @@ export async function recalculateDiscrepancies(program: string, period: string) 
   return res.json();
 }
 
-// This endpoint is corrected to match the backend controller.
+// Fetch accounts for a BAC using the correct backend route.
 export async function fetchAccountsByBac(bac: string) {
-  const res = await fetch(`${API_URL}/discrepancies/accounts/${bac}`);
-  if (!res.ok) throw new Error("Failed to fetch accounts for BAC");
+  const params = new URLSearchParams({ bac });
+  const res = await fetch(`${API_URL}/discrepancies/accounts-by-bac?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch accounts for BAC');
   return res.json();
 }
 

--- a/di-billing-app/apps/web/src/components/DiscrepanciesTable.tsx
+++ b/di-billing-app/apps/web/src/components/DiscrepanciesTable.tsx
@@ -53,8 +53,10 @@ export const DiscrepanciesTable = ({ data = [], onRowSelect, selectedIds }) => {
   };
 
   const handleRowClick = (row: any) => {
-    // This is feature #1: Clicking a row navigates to the (future) details page.
-    navigate(`/discrepancies/${row.original.id}`);
+    const id = row.original.id;
+    if (id) {
+      navigate(`/discrepancies/${id}`);
+    }
   };
   
   return (

--- a/di-billing-app/apps/web/src/components/DiscrepancyDetailsPane.tsx
+++ b/di-billing-app/apps/web/src/components/DiscrepancyDetailsPane.tsx
@@ -1,14 +1,37 @@
 // [SOURCE: apps/web/src/components/DiscrepancyDetailsPane.tsx]
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams, useNavigate } from 'react-router-dom';
 import { fetchDiscrepancyDetails } from '../api';
-import { FaTimes, FaSpinner } from 'react-icons/fa';
+import { FaTimes, FaSpinner, FaPlus } from 'react-icons/fa';
 import { LinesPanel } from './LinesPanel';
+import { AddToReportModal } from './AddToReportModal';
 
 export const DiscrepancyDetailsPane = () => {
   const { discrepancyId } = useParams();
   const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [width, setWidth] = useState(() => window.innerWidth / 2);
+
+  useEffect(() => {
+    const handleResize = () => setWidth(prev => Math.min(prev, window.innerWidth));
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const startResize = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const onMouseMove = (ev: MouseEvent) => {
+      const newWidth = Math.min(Math.max(window.innerWidth - ev.clientX, 300), window.innerWidth - 100);
+      setWidth(newWidth);
+    };
+    const stopResize = () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', stopResize);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', stopResize);
+  };
 
   const detailsQuery = useQuery({
     queryKey: ['discrepancyDetails', discrepancyId],
@@ -20,18 +43,36 @@ export const DiscrepancyDetailsPane = () => {
     navigate('/discrepancies');
   };
 
+  const discrepancy = detailsQuery.data?.discrepancy;
+
   return (
-    <div className="fixed top-0 right-0 h-full w-1/2 bg-[#10171B] border-l border-slate-800 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out">
+    <div
+      className="fixed top-0 right-0 h-full bg-[#10171B] border-l border-slate-800 shadow-2xl z-50 transform transition-transform duration-300 ease-in-out relative"
+      style={{ width }}
+    >
+      <div
+        onMouseDown={startResize}
+        className="absolute left-0 top-0 h-full w-1 cursor-ew-resize bg-slate-700/50"
+      />
       <div className="flex flex-col h-full">
         <header className="flex items-center justify-between p-4 border-b border-slate-800 flex-shrink-0">
           <div>
             <h2 className="text-xl font-bold">Discrepancy Details</h2>
-            {/* This is the fix: Safely access the nested 'bac' property. */}
-            {detailsQuery.data?.discrepancy && <span className="text-sm text-slate-400">BAC: {detailsQuery.data.discrepancy.bac}</span>}
+            {discrepancy && <span className="text-sm text-slate-400">BAC: {discrepancy.bac}</span>}
           </div>
-          <button onClick={handleClose} className="p-2 rounded-lg hover:bg-slate-800/60">
-            <FaTimes />
-          </button>
+          <div className="flex items-center gap-2">
+            {discrepancy && (
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="flex items-center gap-1 px-3 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 text-white text-sm"
+              >
+                <FaPlus /> Add to Report
+              </button>
+            )}
+            <button onClick={handleClose} className="p-2 rounded-lg hover:bg-slate-800/60">
+              <FaTimes />
+            </button>
+          </div>
         </header>
         <div className="flex-1 overflow-y-auto">
           {detailsQuery.isLoading ? (
@@ -46,10 +87,10 @@ export const DiscrepancyDetailsPane = () => {
           ) : detailsQuery.data ? (
             <div className="flex">
               <div className="w-1/2">
-                <LinesPanel title="Salesforce Lines" lines={detailsQuery.data.sfLines} />
+                <LinesPanel title="Salesforce Lines" lines={detailsQuery.data.sfLines} type="sf" />
               </div>
               <div className="w-1/2 border-l border-slate-800">
-                <LinesPanel title="GM Invoice Lines" lines={detailsQuery.data.gmLines} />
+                <LinesPanel title="GM Invoice Lines" lines={detailsQuery.data.gmLines} type="gm" />
               </div>
             </div>
           ) : (
@@ -57,6 +98,14 @@ export const DiscrepancyDetailsPane = () => {
           )}
         </div>
       </div>
+      {isModalOpen && discrepancy && (
+        <AddToReportModal
+          onClose={() => setIsModalOpen(false)}
+          discrepancies={[discrepancy]}
+          program={discrepancy.program}
+          period={discrepancy.period}
+        />
+      )}
     </div>
   );
 };

--- a/di-billing-app/apps/web/src/components/LinesPanel.tsx
+++ b/di-billing-app/apps/web/src/components/LinesPanel.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { fetchDiscrepancyDetails } from '../api';
-import { FaSpinner, FaSort, FaSortUp, FaSortDown } from 'react-icons/fa';
-
-const dollar = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa';
 
 type Line = {
   productCode: string;
@@ -15,35 +11,14 @@ type Line = {
 
 type SortConfig<T> = { key: keyof T | 'totalPrice'; direction: 'asc' | 'desc' } | null;
 
-const SortableHeader = ({ title, sortKey, sortConfig, setSortConfig, className = '' }) => {
-    const isSorted = sortConfig?.key === sortKey;
-    const direction = isSorted ? sortConfig.direction : null;
-  
-    const handleClick = () => {
-      let newDirection: 'asc' | 'desc' = 'desc';
-      if (isSorted && direction === 'desc') {
-        newDirection = 'asc';
-      }
-      setSortConfig({ key: sortKey, direction: newDirection });
-    };
-  
-    return (
-      <th className={`px-3 py-2 font-medium cursor-pointer hover:bg-slate-800 ${className}`} onClick={handleClick}>
-        <div className={`flex items-center gap-2 ${className.includes('text-right') ? 'justify-end' : 'justify-start'}`}>
-          <span>{title}</span>
-          {direction === 'asc' ? <FaSortUp /> : direction === 'desc' ? <FaSortDown /> : <FaSort className="opacity-30" />}
-        </div>
-      </th>
-    );
-};
-
-const LineItemTable = ({ title, lines, type }: { title: string, lines: Line[], type: 'sf' | 'gm' }) => {
+export const LinesPanel = ({ title, lines, type }: { title: string; lines: Line[]; type: 'sf' | 'gm' }) => {
   const [sortConfig, setSortConfig] = useState<SortConfig<Line>>({ key: 'totalPrice', direction: 'desc' });
 
   const sortedLines = useMemo(() => {
     if (!sortConfig) return lines;
     return [...lines].sort((a, b) => {
-      let aValue, bValue;
+      let aValue: any;
+      let bValue: any;
       if (sortConfig.key === 'totalPrice') {
         aValue = a.unitPrice * a.qty;
         bValue = b.unitPrice * b.qty;
@@ -51,14 +26,33 @@ const LineItemTable = ({ title, lines, type }: { title: string, lines: Line[], t
         aValue = a.account?.name || '';
         bValue = b.account?.name || '';
       } else {
-        aValue = a[sortConfig.key];
-        bValue = b[sortConfig.key];
+        aValue = (a as any)[sortConfig.key];
+        bValue = (b as any)[sortConfig.key];
       }
       if (aValue < bValue) return sortConfig.direction === 'asc' ? -1 : 1;
       if (aValue > bValue) return sortConfig.direction === 'asc' ? 1 : -1;
       return 0;
     });
   }, [lines, sortConfig]);
+
+  const handleSort = (key: SortConfig<Line>['key']) => {
+    setSortConfig(prev => {
+      if (prev && prev.key === key) {
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, direction: 'desc' };
+    });
+  };
+
+  const renderSortIcon = (key: SortConfig<Line>['key']) => {
+    if (sortConfig?.key !== key) return <FaSort className="opacity-30" />;
+    return sortConfig.direction === 'asc' ? <FaSortUp /> : <FaSortDown />;
+  };
+
+  const total = useMemo(
+    () => lines.reduce((sum, l) => sum + l.unitPrice * l.qty, 0),
+    [lines]
+  );
 
   return (
     <div className="border border-slate-800 rounded-xl overflow-hidden">
@@ -68,46 +62,58 @@ const LineItemTable = ({ title, lines, type }: { title: string, lines: Line[], t
       <table className="w-full text-sm">
         <thead className="text-slate-300">
           <tr className="text-left">
-            {type === 'sf' && <SortableHeader title="Account Name" sortKey="account" sortConfig={sortConfig} setSortConfig={setSortConfig} />}
-            <SortableHeader title="Product Code" sortKey="productCode" sortConfig={sortConfig} setSortConfig={setSortConfig} />
-            <SortableHeader title="Total Price" sortKey="totalPrice" sortConfig={sortConfig} setSortConfig={setSortConfig} className="text-right" />
+            {type === 'sf' && (
+              <th className="px-3 py-2 font-medium cursor-pointer hover:bg-slate-800" onClick={() => handleSort('account')}>
+                <div className="flex items-center gap-2">
+                  <span>Account Name</span>
+                  {renderSortIcon('account')}
+                </div>
+              </th>
+            )}
+            <th className="px-3 py-2 font-medium cursor-pointer hover:bg-slate-800" onClick={() => handleSort('productCode')}>
+              <div className="flex items-center gap-2">
+                <span>Product Code</span>
+                {renderSortIcon('productCode')}
+              </div>
+            </th>
+            <th
+              className="px-3 py-2 font-medium cursor-pointer hover:bg-slate-800 text-right"
+              onClick={() => handleSort('totalPrice')}
+            >
+              <div className="flex items-center gap-2 justify-end">
+                <span>Total Price</span>
+                {renderSortIcon('totalPrice')}
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
           {sortedLines.length === 0 ? (
-            <tr><td colSpan={3} className="px-3 py-6 text-center text-slate-500">No lines found</td></tr>
+            <tr>
+              <td colSpan={type === 'sf' ? 3 : 2} className="px-3 py-6 text-center text-slate-500">
+                No lines found
+              </td>
+            </tr>
           ) : (
             sortedLines.map((line, idx) => (
               <tr key={idx} className="border-t border-slate-800">
                 {type === 'sf' && <td className="px-3 py-2 text-slate-400 text-xs">{line.account?.name}</td>}
                 <td className="px-3 py-2 font-mono text-xs">{line.productCode || line.name || 'N/A'}</td>
-                <td className="px-3 py-2 text-right">{dollar(line.unitPrice * line.qty)}</td>
+                <td className="px-3 py-2 text-right">
+                  {(line.unitPrice * line.qty).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                </td>
               </tr>
             ))
           )}
         </tbody>
+        <tfoot>
+          <tr className="border-t border-slate-800 font-semibold bg-slate-900/40">
+            {type === 'sf' && <td />}
+            <td className="px-3 py-2 text-right">Total</td>
+            <td className="px-3 py-2 text-right">{total.toLocaleString(undefined, { maximumFractionDigits: 0 })}</td>
+          </tr>
+        </tfoot>
       </table>
-    </div>
-  );
-};
-
-export const LinesPanel = ({ bac, program, period }: { bac: string, program: string, period: string }) => {
-  const detailsQuery = useQuery({
-    queryKey: ['discrepancyDetails', bac, program, period],
-    queryFn: () => fetchDiscrepancyDetails(bac, program, period),
-  });
-
-  if (detailsQuery.isLoading) {
-    return <div className="flex justify-center items-center h-48 text-slate-400"><FaSpinner className="animate-spin mr-2" />Loading details...</div>;
-  }
-  if (detailsQuery.isError) {
-    return <div className="text-center text-rose-400">Error loading details.</div>;
-  }
-
-  return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <LineItemTable title="Salesforce Subscriptions" lines={detailsQuery.data?.sfLines || []} type="sf" />
-      <LineItemTable title="GM Invoice Lines" lines={detailsQuery.data?.gmLines || []} type="gm" />
     </div>
   );
 };

--- a/di-billing-app/apps/web/src/pages/DiscrepanciesPage.tsx
+++ b/di-billing-app/apps/web/src/pages/DiscrepanciesPage.tsx
@@ -1,6 +1,6 @@
 // [SOURCE: apps/web/src/pages/DiscrepanciesPage.tsx]
 import React, { useState, useMemo, useRef } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { fetchDiscrepancies } from '../api';
 import { DiscrepanciesTable } from '../components/DiscrepanciesTable';
 import { PaginationControls } from '../components/PaginationControls';
@@ -11,14 +11,14 @@ import { ReportPane } from '../components/ReportPane';
 import { Outlet } from 'react-router-dom'; // Import Outlet
 
 export const DiscrepanciesPage = () => {
-  const queryClient = useQueryClient();
   const { sorting, pagination, setPagination } = useDiscrepancyStore();
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isReportPaneOpen, setIsReportPaneOpen] = useState(false);
   const lastSelectedIndex = useRef<number | null>(null);
+  const [filters, setFilters] = useState<{ bac: string; program: string }>({ bac: '', program: '' });
 
-  const queryParams = { ...sorting, ...pagination };
+  const queryParams = { ...sorting, ...pagination, ...filters };
 
   const discrepanciesQuery = useQuery({
     queryKey: ['discrepancies', queryParams],
@@ -63,6 +63,29 @@ export const DiscrepanciesPage = () => {
         <div className="flex items-center justify-between p-4 border-b border-slate-800">
           <h1 className="text-2xl font-bold">Discrepancies</h1>
           <div className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="BAC"
+              value={filters.bac}
+              onChange={(e) => {
+                setPagination({ page: 1 });
+                setFilters(f => ({ ...f, bac: e.target.value }));
+              }}
+              className="h-10 bg-slate-800 border border-slate-700 rounded-lg px-2"
+            />
+            <select
+              value={filters.program}
+              onChange={(e) => {
+                setPagination({ page: 1 });
+                setFilters(f => ({ ...f, program: e.target.value }));
+              }}
+              className="h-10 bg-slate-800 border border-slate-700 rounded-lg px-2"
+            >
+              <option value="">All Programs</option>
+              <option value="WEBSITE">Website</option>
+              <option value="CHAT">Chat</option>
+              <option value="TRADE">Trade</option>
+            </select>
             <button onClick={() => setIsModalOpen(true)} disabled={selectedIds.length === 0} className="flex items-center gap-2 px-4 h-10 rounded-lg bg-cyan-600 hover:bg-cyan-500 text-white font-medium disabled:opacity-50">
               <FaPlus />
               Add to Report {selectedIds.length > 0 ? `(${selectedIds.length})` : ''}

--- a/di-billing-app/apps/web/src/pages/ReportsPage.tsx
+++ b/di-billing-app/apps/web/src/pages/ReportsPage.tsx
@@ -65,7 +65,7 @@ export const ReportsPage = () => {
                                         <button onClick={() => handleDownload(report.id, report.name)} className="text-slate-400 hover:text-white">
                                             <FaDownload />
                                         </button>
-                                        <button onClick={() => deleteMutation.mutate(report.id)} disabled={deleteMutation.isPending} className="text-slate-400 hover:text-rose-500 disabled:opacity-50">
+                                        <button onClick={() => deleteMutation.mutate(report.id)} disabled={deleteMutation.isPending} className="text-red-500 hover:text-red-400 disabled:opacity-50">
                                             {deleteMutation.isPending && deleteMutation.variables === report.id ? <FaSpinner className="animate-spin" /> : <FaTrash />}
                                         </button>
                                     </div>


### PR DESCRIPTION
## Summary
- make discrepancy detail pane resizable and allow adding directly to reports
- show totals for Salesforce and GM lines and normalize BAC sums when recalculating
- enable account dropdown when editing multi-account report entries

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7313988c8325939d38e98e1b64b9